### PR TITLE
Implementation of neutronium ingot 实现中子锭相关功能

### DIFF
--- a/src/generated/resources/assets/anvilcraft/lang/en_ud.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_ud.json
@@ -374,6 +374,7 @@
   "item.anvilcraft.negative_matter": "ɹǝʇʇɐW ǝʌıʇɐbǝN",
   "item.anvilcraft.negative_matter_nugget": "ʇǝbbnN ɹǝʇʇɐW ǝʌıʇɐbǝN",
   "item.anvilcraft.netherite_crystal_nucleus": "snǝןɔnN ןɐʇsʎɹƆ ǝʇıɹǝɥʇǝN",
+  "item.anvilcraft.neutronium_ingot": "ʇobuI ɯnıuoɹʇnǝN",
   "item.anvilcraft.oil_bucket": "ʇǝʞɔnᗺ ןıO",
   "item.anvilcraft.orange_cement_bucket": "ʇǝʞɔnᗺ ʇuǝɯǝƆ ǝbuɐɹO",
   "item.anvilcraft.pink_cement_bucket": "ʇǝʞɔnᗺ ʇuǝɯǝƆ ʞuıԀ",

--- a/src/generated/resources/assets/anvilcraft/lang/en_us.json
+++ b/src/generated/resources/assets/anvilcraft/lang/en_us.json
@@ -374,6 +374,7 @@
   "item.anvilcraft.negative_matter": "Negative Matter",
   "item.anvilcraft.negative_matter_nugget": "Negative Matter Nugget",
   "item.anvilcraft.netherite_crystal_nucleus": "Netherite Crystal Nucleus",
+  "item.anvilcraft.neutronium_ingot": "Neutronium Ingot",
   "item.anvilcraft.oil_bucket": "Oil Bucket",
   "item.anvilcraft.orange_cement_bucket": "Orange Cement Bucket",
   "item.anvilcraft.pink_cement_bucket": "Pink Cement Bucket",

--- a/src/generated/resources/assets/anvilcraft/models/item/neutronium_ingot.json
+++ b/src/generated/resources/assets/anvilcraft/models/item/neutronium_ingot.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "anvilcraft:item/neutronium_ingot"
+  }
+}

--- a/src/generated/resources/data/anvilcraft/advancement/recipe/block_compress/space_overcompressor.json
+++ b/src/generated/resources/data/anvilcraft/advancement/recipe/block_compress/space_overcompressor.json
@@ -1,0 +1,21 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "anvilcraft:block_compress/space_overcompressor"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "anvilcraft:block_compress/space_overcompressor"
+    ]
+  }
+}

--- a/src/generated/resources/data/anvilcraft/recipe/block_compress/space_overcompressor.json
+++ b/src/generated/resources/data/anvilcraft/recipe/block_compress/space_overcompressor.json
@@ -1,0 +1,8 @@
+{
+  "type": "anvilcraft:block_compress",
+  "inputs": [
+    "anvilcraft:void_matter_block",
+    "anvilcraft:supercritical_nesting_shulker_box"
+  ],
+  "result": "anvilcraft:space_overcompressor"
+}

--- a/src/generated/resources/data/anvilcraft/tags/block/neutronium_cannot_pass_through.json
+++ b/src/generated/resources/data/anvilcraft/tags/block/neutronium_cannot_pass_through.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "minecraft:end_stone",
+    "minecraft:bedrock",
+    "anvilcraft:end_dust",
+    "anvilcraft:negative_matter_block"
+  ]
+}

--- a/src/generated/resources/data/anvilcraft/tags/item/explosion_proof.json
+++ b/src/generated/resources/data/anvilcraft/tags/item/explosion_proof.json
@@ -17,6 +17,7 @@
     "anvilcraft:ember_anvil_hammer",
     "anvilcraft:ember_metal_ingot",
     "anvilcraft:ember_metal_nugget",
+    "anvilcraft:neutronium_ingot",
     "anvilcraft:earth_core_shard_block",
     "anvilcraft:earth_core_shard_ore",
     "anvilcraft:earth_core_shard"

--- a/src/main/java/dev/dubhe/anvilcraft/api/tooltip/ItemTooltipManager.java
+++ b/src/main/java/dev/dubhe/anvilcraft/api/tooltip/ItemTooltipManager.java
@@ -107,8 +107,7 @@ public class ItemTooltipManager {
         }
         if (stack.is(ModItemTags.REINFORCED_CONCRETE)) {
             ResourceLocation key = BuiltInRegistries.ITEM.getKey(item);
-            tooltip.add(
-                1,
+            tooltip.add(1,
                 Component.translatable("tooltip.%s.item.reinforced_concrete".formatted(key.getNamespace()))
                     .withStyle(ChatFormatting.GRAY));
         }

--- a/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
+++ b/src/main/java/dev/dubhe/anvilcraft/data/tags/BlockTagLoader.java
@@ -128,5 +128,11 @@ public class BlockTagLoader {
         provider.addTag(ModBlockTags.INCORRECT_FOR_EMBER_TOOL);
 
         provider.addTag(ModBlockTags.END_PORTAL_UNABLE_CHANGE).add(findResourceKey(Blocks.DRAGON_EGG));
+
+        provider.addTag(ModBlockTags.NEUTRONIUM_CANNOT_PASS_THROUGH)
+            .add(findResourceKey(Blocks.END_STONE))
+            .add(findResourceKey(Blocks.BEDROCK))
+            .add(findResourceKey(ModBlocks.END_DUST.get()))
+            .add(findResourceKey(ModBlocks.NEGATIVE_MATTER_BLOCK.get()));
     }
 }

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModBlockTags.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModBlockTags.java
@@ -22,6 +22,7 @@ public class ModBlockTags {
     public static final TagKey<Block> BLOCK_DEVOURER_PROBABILITY_DROPPING = bind("block_devourer_probability_dropping");
     public static final TagKey<Block> LASER_CAN_PASS_THROUGH = bind("laser_can_pass_though");
     public static final TagKey<Block> END_PORTAL_UNABLE_CHANGE = bind("end_portal_unable_change");
+    public static final TagKey<Block> NEUTRONIUM_CANNOT_PASS_THROUGH = bind("neutronium_cannot_pass_through");
 
     // common tags
     public static final TagKey<Block> ORES_TUNGSTEN = bindC("ores/tungsten");

--- a/src/main/java/dev/dubhe/anvilcraft/init/ModItems.java
+++ b/src/main/java/dev/dubhe/anvilcraft/init/ModItems.java
@@ -37,6 +37,7 @@ import dev.dubhe.anvilcraft.item.RoyalSwordItem;
 import dev.dubhe.anvilcraft.item.RoyalUpgradeTemplateItem;
 import dev.dubhe.anvilcraft.item.SeedsPackItem;
 import dev.dubhe.anvilcraft.item.StructureToolItem;
+import dev.dubhe.anvilcraft.item.SuperHeavyItem;
 import dev.dubhe.anvilcraft.item.TopazItem;
 import dev.dubhe.anvilcraft.item.UtusanItem;
 import dev.dubhe.anvilcraft.util.ModelProviderUtil;
@@ -1452,6 +1453,13 @@ public class ModItems {
                     AnvilCraftDatagen.has(ModItems.NEGATIVE_MATTER))
                 .save(provider, AnvilCraft.of(BuiltInRegistries.ITEM.getKey(ctx.get()).getPath() + "_from_ingot"));
         })
+        .register();
+
+
+    public static final ItemEntry<SuperHeavyItem> NEUTRONIUM_INGOT = REGISTRATE
+        .item("neutronium_ingot", SuperHeavyItem::new)
+        .initialProperties(() -> new Item.Properties().fireResistant())
+        .tag(ModItemTags.EXPLOSION_PROOF)
         .register();
 
     public static final ItemEntry<BucketItem> OIL_BUCKET = REGISTRATE

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/EmberAnvilMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/EmberAnvilMenu.java
@@ -242,7 +242,7 @@ public class EmberAnvilMenu extends AnvilMenu {
         super.onTake(player, stack);
         Level level = player.level();
         if (level.isClientSide()) return;
-        int curedNumber = ICursed.hasCuredNumber(player);
+        int curedNumber = ICursed.hasCursedNumber(player);
         if (curedNumber <= 0) return;
         LightningBolt bolt = new LightningBolt(EntityType.LIGHTNING_BOLT, level);
         bolt.setPos(player.getX(), player.getY(), player.getZ());

--- a/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalAnvilMenu.java
+++ b/src/main/java/dev/dubhe/anvilcraft/inventory/RoyalAnvilMenu.java
@@ -243,7 +243,7 @@ public class RoyalAnvilMenu extends AnvilMenu {
         super.onTake(player, stack);
         Level level = player.level();
         if (level.isClientSide()) return;
-        int curedNumber = ICursed.hasCuredNumber(player);
+        int curedNumber = ICursed.hasCursedNumber(player);
         if (curedNumber <= 0) return;
         LightningBolt bolt = new LightningBolt(EntityType.LIGHTNING_BOLT, level);
         bolt.setPos(player.getX(), player.getY(), player.getZ());

--- a/src/main/java/dev/dubhe/anvilcraft/item/ISuperHeavy.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/ISuperHeavy.java
@@ -7,13 +7,12 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
-
 import org.jetbrains.annotations.NotNull;
 
 /**
  * 诅咒物品
  */
-public interface ICursed {
+public interface ISuperHeavy {
     /**
      * 执行效果
      *
@@ -26,31 +25,27 @@ public interface ICursed {
     default void inventoryTick(ItemStack stack, Level level, Entity entity, int slotId, boolean isSelected) {
         if (!(entity instanceof Player player)) return;
         if (player.getAbilities().instabuild || player.getAbilities().invulnerable) return;
-        MobEffectInstance weakness = new MobEffectInstance(MobEffects.WEAKNESS, 200, 1, false, true);
-        MobEffectInstance slowness = new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, 200, 1, false, true);
-        MobEffectInstance hungry = new MobEffectInstance(MobEffects.HUNGER, 200, 1, false, true);
-        player.addEffect((weakness));
-        int curedNumber = ICursed.hasCursedNumber(player);
-        if (curedNumber > 8) {
-            player.addEffect((slowness));
-        }
-        if (curedNumber > 64) {
-            player.addEffect((hungry));
-        }
+        int superHeavyItemCount = hasSuperHeavyNumber(player);
+        int amplifier = 0;
+        if(superHeavyItemCount > 64) amplifier = 3;
+        else if(superHeavyItemCount > 16) amplifier = 2;
+        else if(superHeavyItemCount > 4) amplifier = 1;
+        MobEffectInstance slowness = new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, 200, amplifier, false, true);
+        player.addEffect(slowness);
     }
 
     /**
-     * 统计诅咒物品数量
+     * 统计超重物品数量
      *
      * @param player 玩家
-     * @return 诅咒物品数量
+     * @return 超重物品数量
      */
-    static int hasCursedNumber(@NotNull Player player) {
+    static int hasSuperHeavyNumber(@NotNull Player player) {
         Inventory inventory = player.getInventory();
         int i = 0;
         for (int j = 0; j < inventory.getContainerSize(); ++j) {
             ItemStack itemStack = inventory.getItem(j);
-            if (!(itemStack.getItem() instanceof ICursed)) continue;
+            if (!(itemStack.getItem() instanceof ISuperHeavy)) continue;
             i += itemStack.getCount();
         }
         return i;

--- a/src/main/java/dev/dubhe/anvilcraft/item/SuperHeavyItem.java
+++ b/src/main/java/dev/dubhe/anvilcraft/item/SuperHeavyItem.java
@@ -1,0 +1,20 @@
+package dev.dubhe.anvilcraft.item;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.NotNull;
+
+public class SuperHeavyItem extends Item implements ISuperHeavy {
+    public SuperHeavyItem(Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    public void inventoryTick(
+            @NotNull ItemStack stack, @NotNull Level level, @NotNull Entity entity, int slotId, boolean isSelected) {
+        super.inventoryTick(stack, level, entity, slotId, isSelected);
+        ISuperHeavy.super.inventoryTick(stack, level, entity, slotId, isSelected);
+    }
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -59,3 +59,6 @@ public-f net.minecraft.world.level.block.state.BlockBehaviour$Properties hasColl
 
 public net.minecraft.client.Minecraft missTime
 public net.minecraft.client.Minecraft handleKeybinds()V
+
+public net.minecraft.world.entity.Entity inBlockState
+public net.minecraft.world.entity.Entity collideWithShapes(Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/AABB;Ljava/util/List;)Lnet/minecraft/world/phys/Vec3; # collideWithShapes


### PR DESCRIPTION
-    为中子锭物品重写了`tick()`方法，原理为执行原版的`ItemEntity#tick()`中执行的大部分操作，但忽略其中流体影响运动、方块的`speedFactor`影响运动的部分，以及用检测方块标签`#anvilcraft:neutronium_cannot_pass_through`的方式，替代原版的`Level#getBlockCollisions()`检测。
-    修复了`ICursed#hasCursedNumber()`方法名的拼写错误。